### PR TITLE
Replace src/=src/ remapping with local src remapping

### DIFF
--- a/remappings.txt
+++ b/remappings.txt
@@ -7,5 +7,5 @@ rng/=lib/pooltogether-rng-contracts/contracts/
 
 v5-prize-pool/=lib/pt-v5-prize-pool/src/
 
-src/=src/
+draw-auction-local/=src/
 test/=test/

--- a/src/DrawAuction.sol
+++ b/src/DrawAuction.sol
@@ -4,10 +4,10 @@ pragma solidity 0.8.17;
 // import "forge-std/console2.sol";
 
 import { PrizePool } from "v5-prize-pool/PrizePool.sol";
-import { PhaseManager, Phase } from "src/abstract/PhaseManager.sol";
-import { OnlyPhaseManager, IDrawAuction } from "src/interfaces/IDrawAuction.sol";
+import { PhaseManager, Phase } from "draw-auction-local/abstract/PhaseManager.sol";
+import { OnlyPhaseManager, IDrawAuction } from "draw-auction-local/interfaces/IDrawAuction.sol";
 import { RNGInterface } from "rng/RNGInterface.sol";
-import { RewardLib } from "src/libraries/RewardLib.sol";
+import { RewardLib } from "draw-auction-local/libraries/RewardLib.sol";
 
 /**
  * @title PoolTogether V5 DrawAuction

--- a/src/TwoPhaseManager.sol
+++ b/src/TwoPhaseManager.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.8.17;
 
-import { IDrawAuction } from "src/interfaces/IDrawAuction.sol";
-import { PhaseManager, Phase } from "src/abstract/PhaseManager.sol";
-import { RNGRequestor, RNGInterface } from "src/abstract/RNGRequestor.sol";
+import { IDrawAuction } from "draw-auction-local/interfaces/IDrawAuction.sol";
+import { PhaseManager, Phase } from "draw-auction-local/abstract/PhaseManager.sol";
+import { RNGRequestor, RNGInterface } from "draw-auction-local/abstract/RNGRequestor.sol";
 
 /// @notice Emitted when the draw auction is set to the zero address
 error DrawAuctionZeroAddress();

--- a/src/erc5164/DrawAuctionDispatcher.sol
+++ b/src/erc5164/DrawAuctionDispatcher.sol
@@ -3,10 +3,10 @@ pragma solidity 0.8.17;
 
 import { PrizePool } from "v5-prize-pool/PrizePool.sol";
 
-import { PhaseManager, Phase } from "src/abstract/PhaseManager.sol";
-import { ISingleMessageDispatcher } from "src/interfaces/ISingleMessageDispatcher.sol";
-import { RewardLib } from "src/libraries/RewardLib.sol";
-import { OnlyPhaseManager, IDrawAuction } from "src/interfaces/IDrawAuction.sol";
+import { PhaseManager, Phase } from "draw-auction-local/abstract/PhaseManager.sol";
+import { ISingleMessageDispatcher } from "draw-auction-local/interfaces/ISingleMessageDispatcher.sol";
+import { RewardLib } from "draw-auction-local/libraries/RewardLib.sol";
+import { OnlyPhaseManager, IDrawAuction } from "draw-auction-local/interfaces/IDrawAuction.sol";
 import { Ownable } from "owner-manager/Ownable.sol";
 
 /**

--- a/src/erc5164/DrawAuctionExecutor.sol
+++ b/src/erc5164/DrawAuctionExecutor.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.8.17;
 
-import { ExecutorAware } from "src/abstract/ExecutorAware.sol";
-import { Phase } from "src/abstract/PhaseManager.sol";
-import { IDrawAuction } from "src/interfaces/IDrawAuction.sol";
+import { ExecutorAware } from "draw-auction-local/abstract/ExecutorAware.sol";
+import { Phase } from "draw-auction-local/abstract/PhaseManager.sol";
+import { IDrawAuction } from "draw-auction-local/interfaces/IDrawAuction.sol";
 
 contract DrawAuctionExecutor is ExecutorAware {
   /* ============ Events ============ */

--- a/src/interfaces/IDrawAuction.sol
+++ b/src/interfaces/IDrawAuction.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.8.17;
 
-import { Phase } from "src/abstract/PhaseManager.sol";
+import { Phase } from "draw-auction-local/abstract/PhaseManager.sol";
 
 /// @notice Thrown when the caller is not the PhaseManager contract.
 error OnlyPhaseManager();

--- a/src/libraries/RewardLib.sol
+++ b/src/libraries/RewardLib.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.17;
 // import "forge-std/console2.sol";
 
 import { PrizePool } from "v5-prize-pool/PrizePool.sol";
-import { Phase } from "src/abstract/PhaseManager.sol";
+import { Phase } from "draw-auction-local/abstract/PhaseManager.sol";
 
 library RewardLib {
   /* ============ Internal Functions ============ */

--- a/test/DrawAuction.t.sol
+++ b/test/DrawAuction.t.sol
@@ -5,9 +5,9 @@ import { ERC20Mock } from "openzeppelin/mocks/ERC20Mock.sol";
 
 import { UD2x18, SD1x18, ConstructorParams, PrizePool, TieredLiquidityDistributor, TwabController } from "v5-prize-pool/PrizePool.sol";
 
-import { DrawAuction } from "src/DrawAuction.sol";
-import { OnlyPhaseManager } from "src/interfaces/IDrawAuction.sol";
-import { Phase } from "src/abstract/PhaseManager.sol";
+import { DrawAuction } from "draw-auction-local/DrawAuction.sol";
+import { OnlyPhaseManager } from "draw-auction-local/interfaces/IDrawAuction.sol";
+import { Phase } from "draw-auction-local/abstract/PhaseManager.sol";
 import { Helpers, RNGInterface } from "test/helpers/Helpers.t.sol";
 
 contract DrawAuctionTest is Helpers {

--- a/test/RNGRequestor.t.sol
+++ b/test/RNGRequestor.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.17;
 
 import { ERC20Mock } from "openzeppelin/mocks/ERC20Mock.sol";
 
-import { RNGRequestor } from "src/abstract/RNGRequestor.sol";
+import { RNGRequestor } from "draw-auction-local/abstract/RNGRequestor.sol";
 import { Helpers, RNGInterface } from "./helpers/Helpers.t.sol";
 
 contract RNGRequestorTest is Helpers {

--- a/test/auctions/TwoPhaseManager.t.sol
+++ b/test/auctions/TwoPhaseManager.t.sol
@@ -3,8 +3,8 @@ pragma solidity 0.8.17;
 
 import "forge-std/Test.sol";
 
-import { IDrawAuction } from "src/interfaces/IDrawAuction.sol";
-import { DrawAuctionZeroAddress } from "src/TwoPhaseManager.sol";
+import { IDrawAuction } from "draw-auction-local/interfaces/IDrawAuction.sol";
+import { DrawAuctionZeroAddress } from "draw-auction-local/TwoPhaseManager.sol";
 import { TwoPhaseManagerHarness, RNGInterface } from "test/harness/TwoPhaseManagerHarness.sol";
 
 contract TwoPhaseManagerTest is Test {

--- a/test/fork/DrawAuctionDispatcherEthereumToOptimismFork.t.sol
+++ b/test/fork/DrawAuctionDispatcherEthereumToOptimismFork.t.sol
@@ -5,9 +5,9 @@ import { ERC20Mock } from "openzeppelin/mocks/ERC20Mock.sol";
 
 import { UD2x18, SD1x18, ConstructorParams, PrizePool, TieredLiquidityDistributor, TwabController } from "v5-prize-pool/PrizePool.sol";
 
-import { DrawAuctionDispatcher, ISingleMessageDispatcher } from "src/erc5164/DrawAuctionDispatcher.sol";
-import { IDrawAuction, DrawAuctionExecutor } from "src/erc5164/DrawAuctionExecutor.sol";
-import { Phase } from "src/abstract/PhaseManager.sol";
+import { DrawAuctionDispatcher, ISingleMessageDispatcher } from "draw-auction-local/erc5164/DrawAuctionDispatcher.sol";
+import { IDrawAuction, DrawAuctionExecutor } from "draw-auction-local/erc5164/DrawAuctionExecutor.sol";
+import { Phase } from "draw-auction-local/abstract/PhaseManager.sol";
 
 import { Helpers, RNGInterface } from "test/helpers/Helpers.t.sol";
 

--- a/test/fork/DrawAuctionExecutorEthereumToOptimismFork.t.sol
+++ b/test/fork/DrawAuctionExecutorEthereumToOptimismFork.t.sol
@@ -6,9 +6,9 @@ import { AddressAliasHelper } from "optimism/vendor/AddressAliasHelper.sol";
 
 import { UD2x18, SD1x18, ConstructorParams, PrizePool, TieredLiquidityDistributor, TwabController } from "v5-prize-pool/PrizePool.sol";
 
-import { DrawAuctionDispatcher, ISingleMessageDispatcher } from "src/erc5164/DrawAuctionDispatcher.sol";
-import { IDrawAuction, DrawAuctionExecutor } from "src/erc5164/DrawAuctionExecutor.sol";
-import { Phase } from "src/abstract/PhaseManager.sol";
+import { DrawAuctionDispatcher, ISingleMessageDispatcher } from "draw-auction-local/erc5164/DrawAuctionDispatcher.sol";
+import { IDrawAuction, DrawAuctionExecutor } from "draw-auction-local/erc5164/DrawAuctionExecutor.sol";
+import { Phase } from "draw-auction-local/abstract/PhaseManager.sol";
 
 import { Helpers, RNGInterface } from "test/helpers/Helpers.t.sol";
 import { IMessageExecutor } from "test/interfaces/IMessageExecutor.sol";

--- a/test/harness/PhaseManagerHarness.sol
+++ b/test/harness/PhaseManagerHarness.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.8.17;
 
-import { PhaseManager, Phase } from "src/abstract/PhaseManager.sol";
+import { PhaseManager, Phase } from "draw-auction-local/abstract/PhaseManager.sol";
 
 contract PhaseManagerHarness is PhaseManager {
   constructor(uint8 _auctionPhases) PhaseManager(_auctionPhases) {}

--- a/test/harness/RewardLibHarness.sol
+++ b/test/harness/RewardLibHarness.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.8.17;
 
-import { RewardLib, Phase, PrizePool } from "src/libraries/RewardLib.sol";
+import { RewardLib, Phase, PrizePool } from "draw-auction-local/libraries/RewardLib.sol";
 
 contract RewardLibHarness {
   PrizePool internal _prizePool;

--- a/test/harness/TwoPhaseManagerHarness.sol
+++ b/test/harness/TwoPhaseManagerHarness.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.8.17;
 
-import { IDrawAuction } from "src/interfaces/IDrawAuction.sol";
-import { TwoPhaseManager, RNGInterface } from "src/TwoPhaseManager.sol";
+import { IDrawAuction } from "draw-auction-local/interfaces/IDrawAuction.sol";
+import { TwoPhaseManager, RNGInterface } from "draw-auction-local/TwoPhaseManager.sol";
 
 contract TwoPhaseManagerHarness is TwoPhaseManager {
   constructor(

--- a/test/helpers/Helpers.t.sol
+++ b/test/helpers/Helpers.t.sol
@@ -6,7 +6,7 @@ import "forge-std/Test.sol";
 import { PrizePool, TieredLiquidityDistributor } from "v5-prize-pool/PrizePool.sol";
 import { RNGInterface } from "rng/RNGInterface.sol";
 
-import { Phase } from "src/abstract/PhaseManager.sol";
+import { Phase } from "draw-auction-local/abstract/PhaseManager.sol";
 
 contract Helpers is Test {
   /* ============ Mock Functions ============ */


### PR DESCRIPTION
Tried to add relative paths, but was having an issue with the prize pool dependency since it still has a `src/=src/` remapping:
![image](https://github.com/GenerationSoftware/pt-v5-draw-auction/assets/40277611/5429b815-6fe2-4462-b943-87faf26e4da5)
> Note that the directory it's looking in is `lib/pt-v5-prize-pool/src/abstract/PhaseManager.sol`, but we are in the draw-auction repo.

To solve this issue, but still remove the problematic `src/=src/` remapping, I changed it to a uniquely-named local remapping: `draw-auction-local/=src/`. This way there should be no conflicts in other remapping directories and other repos can use the `draw-auction/=<path-to-lib>` remapping if needed.

- Removed `src/=src/` remapping
- Added local `draw-auction-local/=src/` remapping to avoid conflict with prize pool `src/=src/` remapping