### PR TITLE
force action to fail if tests fail

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,6 +29,13 @@ jobs:
           forge build --sizes --via-ir
         id: build
 
+      - name: Run Forge test
+        env:
+          MAINNET_RPC_URL: ${{ secrets.MAINNET_RPC_URL }}
+        run: |
+          forge test
+        id: test
+
       - name: Install lcov
         uses: hrishikesh-kadam/setup-lcov@v1.0.0
 


### PR DESCRIPTION
Github action now fails if tests fail, not just if coverage fails.

~Fixed RNG payment tests that were failing due to the change in payment logic.~
already done in: https://github.com/GenerationSoftware/pt-v5-draw-auction/pull/14