### PR TITLE
allocate rewards instead of distributing

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,7 +20,7 @@
 [submodule "lib/pt-v5-prize-pool"]
 	path = lib/pt-v5-prize-pool
 	url = https://github.com/generationsoftware/pt-v5-prize-pool
-	branch = prod-deploy-1
+	branch = gen-440-auctions-allocate-fees-instead-of-withdrawreserve-c4-92
 [submodule "lib/remote-owner"]
 	path = lib/remote-owner
 	url = https://github.com/generationsoftware/remote-owner

--- a/.gitmodules
+++ b/.gitmodules
@@ -20,7 +20,7 @@
 [submodule "lib/pt-v5-prize-pool"]
 	path = lib/pt-v5-prize-pool
 	url = https://github.com/generationsoftware/pt-v5-prize-pool
-	branch = gen-440-auctions-allocate-fees-instead-of-withdrawreserve-c4-92
+	branch = main
 [submodule "lib/remote-owner"]
 	path = lib/remote-owner
 	url = https://github.com/generationsoftware/remote-owner

--- a/src/RngAuction.sol
+++ b/src/RngAuction.sol
@@ -118,12 +118,12 @@ contract RngAuction is IAuction, Ownable {
 
   /**
    * @notice Emitted when the auction is completed.
-   * @param recipient The recipient of the auction awards
+   * @param recipient The recipient of the auction reward
    * @param sequenceId The sequence ID for the auction
    * @param rng The RNGInterface that was used for this auction
    * @param rngRequestId The RNGInterface request ID
    * @param elapsedTime The amount of time that the auction ran for in seconds
-   * @param rewardFraction The fraction of the available rewards to be sent to the recipient
+   * @param rewardFraction The fraction of the available rewards to be allocated to the recipient
    */
   event RngAuctionCompleted(
     address indexed sender,
@@ -181,7 +181,9 @@ contract RngAuction is IAuction, Ownable {
    *          the funds to the RNG service before calling this function.
    * @dev     If there is a pending RNG service (see _nextRng), it will be swapped in before the
    *          auction is completed.
-   * @param _rewardRecipient Address that will receive the auction reward for starting the RNG request
+   * @param _rewardRecipient Address that will be allocated the auction reward for starting the RNG request.
+   * The recipient can withdraw the rewards from the Prize Pools that use the random number once all
+   * subsequent auctions are complete.
    */
   function startRngRequest(address _rewardRecipient) external {
     if (_rewardRecipient == address(0)) revert RewardRecipientIsZero();

--- a/src/RngRelayAuction.sol
+++ b/src/RngRelayAuction.sol
@@ -138,7 +138,7 @@ contract RngRelayAuction is IRngAuctionRelayListener, IAuction {
   /// @notice Called by the relayer to complete the Rng relay auction.
   /// @param _randomNumber The random number that was generated
   /// @param _rngCompletedAt The timestamp that the RNG was completed at
-  /// @param _rewardRecipient The recipient of the relay auction reward
+  /// @param _rewardRecipient The recipient of the relay auction reward (the recipient can withdraw the rewards from the Prize Pool once the auction is complete)
   /// @param _sequenceId The sequence ID of the auction
   /// @param _rngAuctionResult The result of the RNG auction
   /// @return The closed draw ID converted to bytes32
@@ -186,9 +186,9 @@ contract RngRelayAuction is IRngAuctionRelayListener, IAuction {
     return bytes32(uint(drawId));
   }
 
-  /// @notice Computes the actual rewards that will be distributed to the recipients using the current Prize Pool reserve.
+  /// @notice Computes the actual rewards that will be allocated to the recipients using the current Prize Pool reserve.
   /// @param __auctionResults The auction results to use for calculation
-  /// @return rewards The rewards that will be distributed
+  /// @return rewards The rewards that will be allocated
   function computeRewards(
     AuctionResult[] calldata __auctionResults
   ) external view returns (uint256[] memory) {
@@ -196,10 +196,10 @@ contract RngRelayAuction is IRngAuctionRelayListener, IAuction {
     return _computeRewards(__auctionResults, totalReserve > maxRewards ? maxRewards : totalReserve);
   }
 
-  /// @notice Computes the actual rewards that will be distributed to the recipients given the passed total reserve
+  /// @notice Computes the actual rewards that will be allocated to the recipients given the passed total reserve
   /// @param __auctionResults The auction results to use for calculation
   /// @param _totalReserve The total reserve to use for calculation
-  /// @return rewards The rewards that will be distributed.
+  /// @return rewards The rewards that will be allocated.
   function computeRewardsWithTotal(
     AuctionResult[] calldata __auctionResults,
     uint256 _totalReserve

--- a/src/RngRelayAuction.sol
+++ b/src/RngRelayAuction.sol
@@ -60,7 +60,7 @@ contract RngRelayAuction is IRngAuctionRelayListener, IAuction {
   /// @param recipient The recipient of the reward
   /// @param index The order in which this reward occurred
   /// @param reward The reward amount
-  event AuctionRewardDistributed(
+  event AuctionRewardAllocated(
     uint32 indexed sequenceId,
     address indexed recipient,
     uint32 indexed index,
@@ -178,8 +178,8 @@ contract RngRelayAuction is IRngAuctionRelayListener, IAuction {
     for (uint8 i = 0; i < _rewards.length; i++) {
       uint96 _reward = _safeCast(_rewards[i]);
       if (_reward > 0) {
-        prizePool.withdrawReserve(auctionResults[i].recipient, _reward);
-        emit AuctionRewardDistributed(_sequenceId, auctionResults[i].recipient, i, _reward);
+        prizePool.allocateRewardFromReserve(auctionResults[i].recipient, _reward);
+        emit AuctionRewardAllocated(_sequenceId, auctionResults[i].recipient, i, _reward);
       }
     }
 

--- a/test/integration/DirectIntegration.t.sol
+++ b/test/integration/DirectIntegration.t.sol
@@ -105,11 +105,11 @@ contract RewardLibTest is Test {
         );
     }
 
-    function mockWithdrawReserve(address to, uint256 amount) public {
+    function mockAllocateRewardFromReserve(address to, uint256 amount) public {
         vm.mockCall(
             address(prizePool),
             abi.encodeWithSelector(
-                prizePool.withdrawReserve.selector,
+                prizePool.allocateRewardFromReserve.selector,
                 to,
                 amount
             ),

--- a/test/integration/DirectIntegration.t.sol
+++ b/test/integration/DirectIntegration.t.sol
@@ -66,7 +66,7 @@ contract RewardLibTest is Test {
 
         vm.roll(block.number + 2); // mine two blocks
 
-        mockCloseDraw(29102676481673041902632991033461445430619272659676223336789171408008386403022);
+        mockCloseDraw(uint256(blockhash(block.number - 1)));
         mockReserve(100e18);
 
         // no reward because it happened instantly


### PR DESCRIPTION
- auction completers can then call `withdrawRewards` on the prize pool to withdraw their balance