### PR TITLE
Allow payable amount to Arbitrum relay for L2 gas

### DIFF
--- a/test/RngAuctionRelayerRemoteOwnerArbitrum.t.sol
+++ b/test/RngAuctionRelayerRemoteOwnerArbitrum.t.sol
@@ -82,9 +82,11 @@ contract RngAuctionRelayerRemoteOwnerArbitrumTest is RngRelayerBaseTest {
     address from = address(this);
     address to = address(remoteOwner);
     bytes32 messageId = MessageLib.computeMessageId(1, from, to, data);
+    uint256 value = 1e16; // payable value passed along
 
     vm.mockCall(
       address(messageDispatcher),
+      value,
       abi.encodeWithSelector(
         IMessageDispatcherArbitrum.dispatchAndProcessMessage.selector,
         remoteOwnerChainId,
@@ -110,7 +112,7 @@ contract RngAuctionRelayerRemoteOwnerArbitrumTest is RngRelayerBaseTest {
     );
 
     assertEq(
-      relayer.relay(
+      relayer.relay{ value: value }(
         messageDispatcher,
         remoteOwnerChainId,
         remoteOwner,


### PR DESCRIPTION
The Arbitrum message dispatcher expects a payable amount to deposit to the L2 to cover gas fees. The relay function must also accept a payable amount and pass it onto the dispatcher when called.